### PR TITLE
rename expect called

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,7 +3,7 @@
 S3method(length,mock)
 export(expect_args)
 export(expect_call)
-export(expect_no_calls)
+export(expect_called)
 export(mock)
 export(mock_args)
 export(mock_calls)

--- a/R/expectations.R
+++ b/R/expectations.R
@@ -5,7 +5,7 @@
 #' call expression (\code{\link{expect_call}}) and/or argument values
 #' (\code{\link{expect_args}}) match the expected.
 #'
-#' With \code{expect_no_calls} you can check how many times has the mock
+#' With \code{expect_called} you can check how many times has the mock
 #' object been called.
 #'
 #' @param mock_object A \code{\link{mock}} object.
@@ -21,7 +21,7 @@
 #' with_mock(summary = m, summary(iris))
 #'
 #' # it has been called once
-#' expect_no_calls(m, 1)
+#' expect_called(m, 1)
 #'
 #' # the first (and only) call's arguments matches summary(iris)
 #' expect_call(m, 1, summary(iris))
@@ -118,7 +118,7 @@ ordinal <- function (x)
 
 #' @export
 #' @rdname call-expectations
-expect_no_calls <- function (mock_object, n)
+expect_called <- function (mock_object, n)
 {
   stopifnot(is_mock(mock_object))
 

--- a/R/mock-object.R
+++ b/R/mock-object.R
@@ -38,7 +38,7 @@
 #' m <- mock(1)
 #' with_mock(summary = m, {
 #'   expect_equal(summary(iris), 1)
-#'   expect_no_calls(m, 1)
+#'   expect_called(m, 1)
 #'   expect_call(m, 1, summary(iris))
 #'   expect_args(m, 1, iris)
 #' })

--- a/man/call-expectations.Rd
+++ b/man/call-expectations.Rd
@@ -4,14 +4,14 @@
 \alias{call-expectations}
 \alias{expect_args}
 \alias{expect_call}
-\alias{expect_no_calls}
+\alias{expect_called}
 \title{Expectation: does the given call match the expected?}
 \usage{
 expect_call(mock_object, n, expected_call)
 
 expect_args(mock_object, n, ...)
 
-expect_no_calls(mock_object, n)
+expect_called(mock_object, n)
 }
 \arguments{
 \item{mock_object}{A \code{\link{mock}} object.}
@@ -28,7 +28,7 @@ call expression (\code{\link{expect_call}}) and/or argument values
 (\code{\link{expect_args}}) match the expected.
 }
 \details{
-With \code{expect_no_calls} you can check how many times has the mock
+With \code{expect_called} you can check how many times has the mock
 object been called.
 }
 \examples{
@@ -39,7 +39,7 @@ m <- mock()
 with_mock(summary = m, summary(iris))
 
 # it has been called once
-expect_no_calls(m, 1)
+expect_called(m, 1)
 
 # the first (and only) call's arguments matches summary(iris)
 expect_call(m, 1, summary(iris))

--- a/man/mock.Rd
+++ b/man/mock.Rd
@@ -62,7 +62,7 @@ library(testthat)
 m <- mock(1)
 with_mock(summary = m, {
   expect_equal(summary(iris), 1)
-  expect_no_calls(m, 1)
+  expect_called(m, 1)
   expect_call(m, 1, summary(iris))
   expect_args(m, 1, iris)
 })

--- a/tests/testthat/test-mock-object.R
+++ b/tests/testthat/test-mock-object.R
@@ -71,7 +71,7 @@ test_that("error for long call is formatted well", {
     expect_call(m, 1, x)
   })
 
-  expect_no_calls(test_mock, 2)
+  expect_called(test_mock, 2)
   
   err <- paste0(
     'expected call x does not mach actual call ',
@@ -162,19 +162,19 @@ test_that("expect args in with_mock", {
 
 test_that("calls are counted", {
   m <- mock()
-  expect_no_calls(m, 0)
+  expect_called(m, 0)
 
   m()
-  expect_no_calls(m, 1)
+  expect_called(m, 1)
 
   m()
-  expect_no_calls(m, 2)
+  expect_called(m, 2)
 })
 
 
 test_that("appropriate message if counts are missing", {
   m <- mock()
-  expect_failure(expect_no_calls(m, 1), "mock object has not been called 1 time")
-  expect_failure(expect_no_calls(m, 2), "mock object has not been called 2 times")
+  expect_failure(expect_called(m, 1), "mock object has not been called 1 time")
+  expect_failure(expect_called(m, 2), "mock object has not been called 2 times")
 })
 

--- a/tests/testthat/test_stub.R
+++ b/tests/testthat/test_stub.R
@@ -146,7 +146,7 @@ test_that('mock object returns value', {
     stub(g, 'f', mock_object)
 
     expect_equal(g('anything'), 1)
-    expect_no_calls(mock_object, 1)
+    expect_called(mock_object, 1)
     expect_args(mock_object, 1, 'anything')
 })
 

--- a/vignettes/mocks-and-testthat.Rmd
+++ b/vignettes/mocks-and-testthat.Rmd
@@ -152,24 +152,24 @@ can for example verify the number and signature of calls invoked on a
 mock function, as well as the values of arguments passed in those calls.
 
 First, let's make sure the mocked function is called exactly as many
-times as we expect. This can be done with `expect_no_calls()`.
+times as we expect. This can be done with `expect_called()`.
 
-```{r expect_no_calls}
+```{r expect_called}
 m <- mock(1, 2)
 
 m()
-expect_no_calls(m, 1)
+expect_called(m, 1)
 
 m()
-expect_no_calls(m, 2)
+expect_called(m, 2)
 ```
 
 And here is what happens when we get the number of calls wrong.
 
-```{r expect_no_calls_error, eval=FALSE}
-expect_no_calls(m, 1)
+```{r expect_called_error, eval=FALSE}
+expect_called(m, 1)
 #> Error: mock object has not been called 1 time.
-expect_no_calls(m, 3)
+expect_called(m, 3)
 #> Error: mock object has not been called 3 times.
 ```
 


### PR DESCRIPTION
@lbartnik 

I'm renaming `expect_no_calls` to `expect_called` as discussed. Let me know if you see any issues, otherwise I'll merge tomorrow.

I think I'll release another version - I've made two breaking changes (this one, and removing a function in the last pull request) and added support for R6 classes since the last version.

