### PR TITLE
Revert "Added failing spec to show that calling external objects when mocking does not work"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: mockery
-Version: 0.3.1
+Version: 0.3.0
 Title: Mocking Library for R
 Description:
     The two main functionalities of this package are creating mock

--- a/R/stub.R
+++ b/R/stub.R
@@ -107,7 +107,7 @@ create_create_new_name_function <- function(stub_list, env, sep)
             }
         }
         code = paste(pkg_name, func_name, sep=sep)
-        return(eval(parse(text=code), env))
+        return(eval(parse(text=code), eval_env))
     }
     attributes(create_new_name) <- list(stub_list=stub_list)
     return(create_new_name)

--- a/tests/testthat/test_stub.R
+++ b/tests/testthat/test_stub.R
@@ -189,38 +189,16 @@ some_class = R6Class("some_class",
     public = list(
         some_method = function() {return(some_function())},
         some_method_prime = function() {return(some_function())},
-        other_method = function() {return('method in class')},
-        method_without_other = function() { self$other_method() },
-        method_with_other = function() {
-          other <- other_class$new()
-          other$external_method()
-          self$other_method()
-        }
-    )
-)
-
-other_class = R6Class("other_class",
-    public = list(
-        external_method = function() {return('this is external output')}
+        other_method = function() {return('method in class')}
     )
 )
 
 # Calling function from R6 method
-some_function = function() {return("called from within class")}
-obj = some_class$new()
+ some_function = function() {return("called from within class")}
+ obj = some_class$new()
 test_that('stub works with R6 methods', {
     stub(obj$some_method, 'some_function', 'stub has been called')
     expect_equal(obj$some_method(), 'stub has been called')
-})
-
-test_that('stub works with R6 methods that call internal methods in them', {
-    stub(obj$method_without_other, 'self$other_method', 'stub has been called')
-    expect_equal(obj$method_without_other(), 'stub has been called')
-})
-
-test_that('stub works with R6 methods that have other objects in them', {
-    stub(obj$method_with_other, 'self$other_method', 'stub has been called')
-    expect_equal(obj$method_with_other(), 'stub has been called')
 })
 
 test_that('R6 method does not stay stubbed', {


### PR DESCRIPTION
Reverts n-s-f/mockery#18