### PR TITLE
Update URLs regarding new github location

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,8 +14,8 @@ Authors@R: c(
     person("Lukasz", "Bartnik", rol = c("aut"),
            email = "l.bartnik@gmail.com")
     )
-URL: https://github.com/n-s-f/mockery
-BugReports: https://github.com/n-s-f/mockery/issues
+URL: https://github.com/jfiksel/mockery
+BugReports: https://github.com/jfiksel/mockery/issues
 Imports:
     testthat
 Suggests:

--- a/R/NEWS.md
+++ b/R/NEWS.md
@@ -1,7 +1,7 @@
 ## mockery 0.3.2
 
-This release addresses issues https://github.com/n-s-f/mockery/issues/17 and
-https://github.com/n-s-f/mockery/issues/13
+This release addresses issues https://github.com/jfiksel/mockery/issues/17 and
+https://github.com/jfiksel/mockery/issues/13
 
 In particular, it is now possible to mock functions out of R6 methods that
 contain other R6 objects. Additionally, it's also possible to specify the depth

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mockery
-[![Travis-CI Build Status](https://travis-ci.org/n-s-f/mockery.svg?branch=master)](https://travis-ci.org/n-s-f/mockery)
-[![Coverage Status](https://img.shields.io/codecov/c/github/n-s-f/mockery/master.svg)](https://codecov.io/github/n-s-f/mockery?branch=master)
+[![Travis-CI Build Status](https://travis-ci.org/jfiksel/mockery.svg?branch=master)](https://travis-ci.org/jfiksel/mockery)
+[![Coverage Status](https://img.shields.io/codecov/c/github/jfiksel/mockery/master.svg)](https://codecov.io/github/jfiksel/mockery?branch=master)
 [![CRAN version](http://www.r-pkg.org/badges/version/mockery)](https://cran.r-project.org/package=mockery)
 [![Downloads](http://cranlogs.r-pkg.org/badges/mockery)](http://cran.rstudio.com/web/packages/mockery/index.html)
 
@@ -22,7 +22,7 @@ To install directly from the source code in this github repository:
 >
 > # Then:
 > library('devtools')
-> devtools::install_github('n-s-f/mockery')
+> devtools::install_github('jfiksel/mockery')
 ```
 
 ### Testing


### PR DESCRIPTION
Not all URLs were automatically forwarded, e.g. the Travis CI build badge
is now correctly shown.